### PR TITLE
Implement basic PoC for ECDSA based signing and verification of tokens

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,8 @@ build-notify:
 	go build ${LDFLAGS} -o bin/proteus-notify proteus-notify/main.go
 build-registry:
 	go build ${LDFLAGS} -o bin/proteus-registry proteus-registry/main.go
+build-orchestrate:
+	go build ${LDFLAGS} -o bin/orchestrate proteus-orchestrate/main.go
 
 proteus: vendor build-all
 

--- a/proteus-orchestrate/cmd/keygen.go
+++ b/proteus-orchestrate/cmd/keygen.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"os"
+	"io/ioutil"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var outputFile string
+
+func keygen() {
+	// pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	priv_key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		panic(err)
+	}
+	priv_key_bytes, err := x509.MarshalECPrivateKey(priv_key)
+	if err != nil {
+		panic(err)
+	}
+	pub_key_bytes, err := x509.MarshalPKIXPublicKey(&priv_key.PublicKey)
+	if err != nil {
+		panic(err)
+	}
+	pem_priv := pem.EncodeToMemory(
+		&pem.Block{Type: "EC PRIVATE KEY", Bytes: priv_key_bytes},
+	)
+	//fmt.Println("pem_priv_block: ")
+	//fmt.Print(string(pem_priv))
+
+	pem_pub := pem.EncodeToMemory(
+		&pem.Block{Type: "EC PUBLIC KEY", Bytes: pub_key_bytes},
+	)
+	//fmt.Println("pem_pub_block: ")
+	//fmt.Print(string(pem_pub))
+	ioutil.WriteFile(outputFile, pem_priv, 0600)
+	ioutil.WriteFile(outputFile + ".pub", pem_pub, 0644)
+}
+
+// keygenCmd represents the keygen command
+var keygenCmd = &cobra.Command{
+	Use:   "keygen",
+	Short: "Generate a keypair for use with proteus orchestration",
+	Long: ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		if _, err := os.Stat(outputFile); !os.IsNotExist(err) {
+			// XXX add confirmation dialog
+			fmt.Printf("WARNING: %s exists. Will overwrite\n", outputFile)
+		}
+		keygen()
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(keygenCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	keygenCmd.PersistentFlags().StringVar(&outputFile, "f", "proteus-key", "Specify where to write the key to")
+}

--- a/proteus-orchestrate/cmd/keygen.go
+++ b/proteus-orchestrate/cmd/keygen.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"os"
+	"strings"
 	"io/ioutil"
 	"crypto/rsa"
 	"crypto/rand"
@@ -35,6 +36,18 @@ func keygen() {
 	ioutil.WriteFile(outputFile + ".pub", pem_pub, 0644)
 }
 
+func askForConfirm() bool {
+	var response string
+	_, err := fmt.Scanln(&response)
+	if err != nil {
+		panic(err)
+	}
+	if (strings.ToLower(string(response[0])) == "y") {
+		return true
+	}
+	return false
+}
+
 // keygenCmd represents the keygen command
 var keygenCmd = &cobra.Command{
 	Use:   "keygen",
@@ -43,7 +56,13 @@ var keygenCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		if _, err := os.Stat(outputFile); !os.IsNotExist(err) {
 			// XXX add confirmation dialog
-			fmt.Printf("WARNING: %s exists. Will overwrite\n", outputFile)
+			fmt.Printf("WARNING: %s exists\n", outputFile)
+			fmt.Printf("overwrite? (y/n) ")
+			if askForConfirm() == false {
+				fmt.Println("ok quiting...")
+				return
+			}
+			fmt.Println("overwriting...")
 		}
 		keygen()
 	},

--- a/proteus-orchestrate/cmd/keygen.go
+++ b/proteus-orchestrate/cmd/keygen.go
@@ -3,8 +3,7 @@ package cmd
 import (
 	"os"
 	"io/ioutil"
-	"crypto/ecdsa"
-	"crypto/elliptic"
+	"crypto/rsa"
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
@@ -16,30 +15,22 @@ import (
 var outputFile string
 
 func keygen() {
-	// pub, priv, err := ed25519.GenerateKey(rand.Reader)
-	priv_key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	priv_key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		panic(err)
 	}
-	priv_key_bytes, err := x509.MarshalECPrivateKey(priv_key)
-	if err != nil {
-		panic(err)
-	}
+	priv_key_bytes := x509.MarshalPKCS1PrivateKey(priv_key)
 	pub_key_bytes, err := x509.MarshalPKIXPublicKey(&priv_key.PublicKey)
 	if err != nil {
 		panic(err)
 	}
 	pem_priv := pem.EncodeToMemory(
-		&pem.Block{Type: "EC PRIVATE KEY", Bytes: priv_key_bytes},
+		&pem.Block{Type: "RSA PRIVATE KEY", Bytes: priv_key_bytes},
 	)
-	//fmt.Println("pem_priv_block: ")
-	//fmt.Print(string(pem_priv))
 
 	pem_pub := pem.EncodeToMemory(
-		&pem.Block{Type: "EC PUBLIC KEY", Bytes: pub_key_bytes},
+		&pem.Block{Type: "RSA PUBLIC KEY", Bytes: pub_key_bytes},
 	)
-	//fmt.Println("pem_pub_block: ")
-	//fmt.Print(string(pem_pub))
 	ioutil.WriteFile(outputFile, pem_priv, 0600)
 	ioutil.WriteFile(outputFile + ".pub", pem_pub, 0644)
 }

--- a/proteus-orchestrate/cmd/root.go
+++ b/proteus-orchestrate/cmd/root.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var cfgFile string
+
+// RootCmd represents the base command when called without any subcommands
+var RootCmd = &cobra.Command{
+	Use:   "proteus-orchestrate",
+	Short: "A brief description of your application",
+	Long: `A longer description that spans multiple lines and likely contains
+examples and usage of using your application. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+// Uncomment the following line if your bare application
+// has an action associated with it:
+//	Run: func(cmd *cobra.Command, args []string) { },
+}
+
+// Execute adds all child commands to the root command sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	if err := RootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(-1)
+	}
+}
+
+func init() {
+	cobra.OnInitialize(initConfig)
+
+	// Here you will define your flags and configuration settings.
+	// Cobra supports Persistent Flags, which, if defined here,
+	// will be global for your application.
+
+	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.proteus-orchestrate.yaml)")
+	// Cobra also supports local flags, which will only run
+	// when this action is called directly.
+	RootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}
+
+// initConfig reads in config file and ENV variables if set.
+func initConfig() {
+	if cfgFile != "" { // enable ability to specify config file via flag
+		viper.SetConfigFile(cfgFile)
+	}
+
+	viper.SetConfigName(".proteus-orchestrate") // name of config file (without extension)
+	viper.AddConfigPath("$HOME")  // adding home directory as first search path
+	viper.AutomaticEnv()          // read in environment variables that match
+
+	// If a config file is found, read it in.
+	if err := viper.ReadInConfig(); err == nil {
+		fmt.Println("Using config file:", viper.ConfigFileUsed())
+	}
+}

--- a/proteus-orchestrate/cmd/sign.go
+++ b/proteus-orchestrate/cmd/sign.go
@@ -27,11 +27,11 @@ func sign(claims ProteusClaims) {
 	if err != nil {
 		panic(err)
 	}
-	privKey, err := jwt.ParseECPrivateKeyFromPEM(keyPEM)
+	privKey, err := jwt.ParseRSAPrivateKeyFromPEM(keyPEM)
 	if err != nil {
 		panic(err)
 	}
-	token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
+	token := jwt.NewWithClaims(jwt.SigningMethodRS512, claims)
 	ss, err := token.SignedString(privKey)
 	if err != nil {
 		panic(err)

--- a/proteus-orchestrate/cmd/sign.go
+++ b/proteus-orchestrate/cmd/sign.go
@@ -1,0 +1,93 @@
+// Copyright © 2017 NAME HERE <EMAIL ADDRESS>
+//
+
+package cmd
+
+import (
+	"os"
+	"encoding/base64"
+	"encoding/json"
+	"io/ioutil"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/crypto/ssh/terminal"
+	"gopkg.in/dgrijalva/jwt-go.v3"
+)
+
+var privKeyPath string
+
+type ProteusClaims struct {
+    Foo string `json:"foo"`
+    jwt.StandardClaims
+}
+
+func sign(claims ProteusClaims) {
+	keyPEM, err := ioutil.ReadFile(privKeyPath)
+	if err != nil {
+		panic(err)
+	}
+	privKey, err := jwt.ParseECPrivateKeyFromPEM(keyPEM)
+	if err != nil {
+		panic(err)
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
+	ss, err := token.SignedString(privKey)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Signed claims: ")
+	fmt.Printf("%v", ss)
+	fmt.Println("")
+}
+
+// signCmd represents the sign command
+var signCmd = &cobra.Command{
+	Use:   "sign",
+	Short: "Used to sign orchestration commands",
+	Long: `Usually this command is run with the output given from the proteus web interface`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if terminal.IsTerminal(0) {
+			// Example:
+			// base64.b64encode(json.dumps({"iss": "art", "exp": 15000, "foo": "bar"}))
+			// eyJpc3MiOiAiYXJ0IiwgImZvbyI6ICJiYXIiLCAiZXhwIjogMTUwMDB9
+			fmt.Println("I require some pipe")
+			return
+		}
+		inBytes, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			panic(err)
+		}
+		jsonBytes, err := base64.StdEncoding.DecodeString(string(inBytes))
+		if err != nil {
+			panic(err)
+		}
+		fmt.Println("I will sign: ")
+		fmt.Print(string(jsonBytes))
+		fmt.Println("")
+		claims := ProteusClaims{}
+
+		err = json.Unmarshal(jsonBytes, &claims)
+		if err != nil {
+			panic(err)
+		}
+		sign(claims)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(signCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// signCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	signCmd.PersistentFlags().StringVar(&privKeyPath, "f", "proteus-key", "Specify where to read private key from")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// signCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+}

--- a/proteus-orchestrate/cmd/verify.go
+++ b/proteus-orchestrate/cmd/verify.go
@@ -1,0 +1,78 @@
+// Copyright © 2017 NAME HERE <EMAIL ADDRESS>
+//
+
+package cmd
+
+import (
+	"os"
+	"io/ioutil"
+	"strings"
+	"crypto/ecdsa"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/crypto/ssh/terminal"
+	"gopkg.in/dgrijalva/jwt-go.v3"
+)
+
+var pubKeyPath string
+
+func verify(tokenString string, pubKey *ecdsa.PublicKey) {
+	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodECDSA); !ok {
+			return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
+		}
+		return pubKey, nil
+	})
+	if claims, ok := token.Claims.(jwt.MapClaims); ok && token.Valid {
+		fmt.Println("TOKEN IS VALID")
+		fmt.Printf("Check passed: %v\n", claims.VerifyIssuer("art", true))
+		fmt.Printf("Issuer      : %v\n", claims["iss"])
+		fmt.Printf("Foo         : %v\n", claims["foo"])
+		fmt.Printf("Expiry      : %v\n", claims["exp"])
+	} else {
+		fmt.Println("ERR: TOKEN IS INVALID")
+		fmt.Println(err)
+	}
+}
+
+// verifyCmd represents the verify command
+var verifyCmd = &cobra.Command{
+	Use:   "verify",
+	Short: "Used to verify that a signed token is valid",
+	Long: `Takes from stdin the signed token and says if the token is valid or not`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if terminal.IsTerminal(0) {
+			fmt.Println("I require some pipe")
+			return
+		}
+		inBytes, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			panic(err)
+		}
+		pubKeyBytes, err := ioutil.ReadFile(pubKeyPath)
+		if err != nil {
+			panic(err)
+		}
+		pubKey, err := jwt.ParseECPublicKeyFromPEM(pubKeyBytes)
+		if err != nil {
+			panic(err)
+		}
+		verify(strings.TrimSpace(string(inBytes)), pubKey)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(verifyCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	verifyCmd.PersistentFlags().StringVar(&pubKeyPath, "f", "proteus-key.pub", "The path to the public key path")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// verifyCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+}

--- a/proteus-orchestrate/cmd/verify.go
+++ b/proteus-orchestrate/cmd/verify.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"io/ioutil"
 	"strings"
-	"crypto/ecdsa"
+	"crypto/rsa"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -17,9 +17,9 @@ import (
 
 var pubKeyPath string
 
-func verify(tokenString string, pubKey *ecdsa.PublicKey) {
+func verify(tokenString string, pubKey *rsa.PublicKey) {
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
-		if _, ok := token.Method.(*jwt.SigningMethodECDSA); !ok {
+		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
 			return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
 		}
 		return pubKey, nil
@@ -54,7 +54,7 @@ var verifyCmd = &cobra.Command{
 		if err != nil {
 			panic(err)
 		}
-		pubKey, err := jwt.ParseECPublicKeyFromPEM(pubKeyBytes)
+		pubKey, err := jwt.ParseRSAPublicKeyFromPEM(pubKeyBytes)
 		if err != nil {
 			panic(err)
 		}

--- a/proteus-orchestrate/main.go
+++ b/proteus-orchestrate/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/thetorproject/proteus/proteus-orchestrate/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/proteus-orchestrate/orchestrate/keystore/keystore.go
+++ b/proteus-orchestrate/orchestrate/keystore/keystore.go
@@ -1,0 +1,224 @@
+package keystore
+
+import (
+	"bytes"
+	"crypto/rsa"
+	"crypto/sha256"
+	"errors"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"syscall"
+
+	"golang.org/x/crypto/ssh/terminal"
+	"github.com/miekg/pkcs11"
+)
+
+const (
+	// KeymodeNone means that no touch or PIN is required to sign with the yubikey
+	KeymodeNone = 0
+	// KeymodeTouch means that only touch is required to sign with the yubikey
+	KeymodeTouch = 1
+	// KeymodePinOnce means that the pin entry is required once the first time to sign with the yubikey
+	KeymodePinOnce = 2
+	// KeymodePinAlways means that pin entry is required every time to sign with the yubikey
+	KeymodePinAlways = 4
+)
+
+var (
+	yubikeyKeymode = KeymodeTouch | KeymodePinAlways
+)
+
+func SetupHSM(libPath string) (*pkcs11.Ctx, pkcs11.SessionHandle, error) {
+	if libPath == "" {
+		return nil, 0, errors.New("libPath is empty")
+	}
+	p := pkcs11.New(libPath)
+	if err := p.Initialize(); err != nil {
+		return nil, 0, fmt.Errorf("found library %s, but initialize error %s", libPath, err.Error())
+	}
+
+	slots, err := p.GetSlotList(true)
+	if err != nil {
+		defer p.Destroy()
+		defer p.Finalize()
+		return nil, 0, fmt.Errorf("loaded library %s, failed to list slots %s", libPath, err)
+	}
+	if len(slots) < 1 {
+		defer p.Destroy()
+		defer p.Finalize()
+		return nil, 0, fmt.Errorf("loaded library %s, but no slots found", libPath)
+	}
+	fmt.Printf("Using slot #%s\n", slots[0])
+	session, err := p.OpenSession(slots[0], pkcs11.CKF_SERIAL_SESSION|pkcs11.CKF_RW_SESSION)
+	if err != nil {
+		defer p.Destroy()
+		defer p.Finalize()
+		defer p.CloseSession(session)
+		return nil, 0, fmt.Errorf("loaded library %s, but failed to start session %s", err)
+	}
+	return p, session, nil
+}
+
+func LoginPrompt(ctx *pkcs11.Ctx, session pkcs11.SessionHandle, userFlag uint) error {
+	var (
+		pinType string
+	)
+	maxAttempts := 2
+	if userFlag == pkcs11.CKU_SO {
+		pinType = "SO"
+	} else {
+		pinType = "User"
+	}
+	for attempts := 0; attempts <= maxAttempts ; attempts++ {
+		fmt.Printf("Enter your %s pin: ", pinType)
+		pinBytes, err := terminal.ReadPassword(int(syscall.Stdin))
+		if err != nil {
+			return err
+		}
+		err = ctx.Login(session, userFlag, string(pinBytes))
+		if err == nil {
+			fmt.Printf("\nLogged in as %s\n", pinType)
+			return nil
+		}
+		fmt.Println("Wrong ping. Try again.")
+	}
+	return errors.New("Incorrect attempts exceeded")
+}
+
+func encodeByteSlice(in ...[]byte) []byte {
+	l := 0
+	for _, v := range in {
+		l += len(v)
+	}
+	if l > 4294967295 {
+		panic(fmt.Errorf("input byte slice is too long"))
+	}
+	out := make([]byte, 4+l)
+	binary.BigEndian.PutUint32(out, uint32(l))
+
+	start := 4 + copy(out[4:], in[0])
+	if len(in) > 1 {
+		for _, v := range in[1:] {
+			copy(out[start:], v)
+		}
+	}
+	return out
+}
+
+func getKeyID(privKey *rsa.PrivateKey) (string, error) {
+	key, ok := privKey.Public().(*rsa.PublicKey)
+	if !ok {
+		return "", errors.New("unsupported type")
+	}
+	buf := bytes.NewBuffer(nil)
+	buf.Write(encodeByteSlice([]byte("rsa")))
+	e := make([]byte, 4)
+	binary.BigEndian.PutUint32(e, uint32(key.E))
+	buf.Write(encodeByteSlice(bytes.TrimLeft(e, "\x00")))
+	buf.Write(encodeByteSlice([]byte{0}, key.N.Bytes()))
+
+	digest := sha256.Sum256(buf.Bytes())
+	keyID := hex.EncodeToString(digest[:])
+
+	return keyID, nil
+}
+
+func AddKey(libPath string, privKey *rsa.PrivateKey) error {
+	/*
+	keyID, err := getKeyID(privKey)
+	if err != nil {
+		return err
+	}
+	*/
+	keyID := 2
+
+	ctx, session, err := SetupHSM(libPath)
+	if err != nil {
+		return err
+	}
+	defer ctx.Destroy()
+	defer ctx.Finalize()
+	defer ctx.CloseSession(session)
+
+	//if err := LoginPrompt(ctx, session, pkcs11.CKU_SO); err != nil {
+	if err := LoginPrompt(ctx, session, pkcs11.CKU_USER); err != nil {
+		return err
+	}
+
+	defer ctx.Logout(session)
+	// XXX check if the key is already on the token
+
+	template := []*pkcs11.Attribute{
+		// Taken from: http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.html#_Toc416959720
+		pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_PRIVATE_KEY),
+		pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, pkcs11.CKK_RSA),
+		pkcs11.NewAttribute(pkcs11.CKA_ID, keyID),
+		pkcs11.NewAttribute(pkcs11.CKA_MODULUS, privKey.PublicKey.N.Bytes()),
+		pkcs11.NewAttribute(pkcs11.CKA_PUBLIC_EXPONENT, privKey.PublicKey.E),
+		pkcs11.NewAttribute(pkcs11.CKA_PRIVATE_EXPONENT, privKey.D.Bytes()),
+		pkcs11.NewAttribute(pkcs11.CKA_PRIME_1, privKey.Primes[0].Bytes()),
+		pkcs11.NewAttribute(pkcs11.CKA_PRIME_2, privKey.Primes[1].Bytes()),
+		pkcs11.NewAttribute(pkcs11.CKA_EXPONENT_1, privKey.Precomputed.Dp.Bytes()),
+		pkcs11.NewAttribute(pkcs11.CKA_EXPONENT_2, privKey.Precomputed.Dq.Bytes()),
+		pkcs11.NewAttribute(pkcs11.CKA_COEFFICIENT, privKey.Precomputed.Qinv.Bytes()),
+		// This is yubikey specific
+		//pkcs11.NewAttribute(pkcs11.CKA_VENDOR_DEFINED, yubikeyKeymode),
+	}
+	_, err = ctx.CreateObject(session, template)
+	if err != nil {
+		return fmt.Errorf("error importing key: %v", err)
+	}
+	return nil
+}
+
+func ListKeys(libPath string) (error) {
+	fmt.Println("Listing keys")
+	ctx, session, err := SetupHSM(libPath)
+	if err != nil {
+		return err
+	}
+	defer ctx.Destroy()
+	defer ctx.Finalize()
+	defer ctx.CloseSession(session)
+	
+	findTemplate := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_PRIVATE_KEY),
+	}
+	attrTemplate := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_ID, []byte{0}),
+	}
+
+	if err = ctx.FindObjectsInit(session, findTemplate); err != nil {
+		return err
+	}
+	objs, _, err := ctx.FindObjects(session, 4)
+	for err == nil {
+		var o []pkcs11.ObjectHandle
+		o, _, err = ctx.FindObjects(session, 4)
+		if err != nil {
+			continue
+		}
+		if len(o) == 0 {
+			break
+		}
+		objs = append(objs, o...)
+	}
+	if err = ctx.FindObjectsFinal(session); err != nil {
+		return err
+	}
+	fmt.Printf("Found %d objects\n", len(objs))
+	for _, obj := range objs {
+		attr, err := ctx.GetAttributeValue(session, obj, attrTemplate)
+		if err != nil {
+			continue
+		}
+		fmt.Println()
+		fmt.Printf("obj: %v\n", obj)
+		for _, a := range attr {
+			fmt.Printf("aatr: %v", a)
+		}
+		fmt.Println()
+	}
+	return nil
+}


### PR DESCRIPTION
This implements a PoC of the idea outlined in: https://github.com/TheTorProject/proteus/issues/24.

To build it run:

```
make build-orchestrate
```

The suggested workflow is as follows.

1. Private key-pairs are generated using the `orchestrate keygen` command:

```
./bin/orchestrate keygen -f /path/to/privkey
```

This will generate a ECDSA keypair using NIST curve P-256 (yeah, it could have a NSA backdoor, etc., but it seems like it's the only interoperable solution if we want to not be sad when we have to write the various verification code, since ED25519 support is openssl is a weak).

The public part of the key needs to be loaded into all the ooniprobe apps that need to support orchestration.

* [ ] TODO: do we want to have one master key we share? Should we have a list of keys that we provision the clients with or some PKI-like approach?

2. The web application will generate a JWT token and give a string to copy paste on your machine for signing it.

This can be simulated by running this python snippet:

```
import base64
import json
import time
print(base64.b64encode(json.dumps({"iss": "art", "exp": int(time.time()+200), "foo": "bar"})))
```

You will get back something that looks like this:

```
eyJpc3MiOiAiYXJ0IiwgImZvbyI6ICJiYXIiLCAiZXhwIjogMTUwMzU2MTg0Mn0=
```

Or the webapp should print out already the full command to sign it:

```
echo eyJpc3MiOiAiYXJ0IiwgImZvbyI6ICJiYXIiLCAiZXhwIjogMTUwMzU2MTg0Mn0= | orchestrate sign
```

3. The OONI operators will generate a signed version of the token via the sign command:

```
echo $BASE64TOKEN | ./bin/orchestrate sign -f /path/to/your/privkey
```

4. The ooniprobe clients need to verify that the token is signed. For PoC purposes a verify command is also implemented. It works like this:

```
echo $SIGNEDTOKEN | ./bin/orchestrate verify -f /path/to/the/pubkey.pub
```

If you did all the above steps correctly you should see something like:

```
TOKEN IS VALID
Check passed: true
Issuer      : art
Foo         : bar
Expiry      : 1.51355745e+09
```

If the token is not valid you will see something like:

```
ERR: TOKEN IS INVALID
Token is expired
```