### PR TITLE
Sync test lists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ fmt-check:
 lint: PACKAGES = $(shell govendor list -no-status +local)
 lint:
 	@hash golint > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
-		go get -u github.com/golang/lint/golint; \
+		go get -u golang.org/x/lint/golint; \
 	fi
 	for PKG in $(PACKAGES); do golint -set_exit_status $$PKG || exit 1; done;
 

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,0 +1,13 @@
+# Build: run ooni-sysadmin.git/scripts/docker-build from this directory
+
+FROM python:2.7
+
+# `psycopg2-binary` brings its own libpq and libssl, see http://initd.org/psycopg/docs/install.html#binary-install-from-pypi
+RUN set -ex \
+    && pip2.7 install --target /usr/local/lib/python2.7/site-packages psycopg2-binary GitPython \
+    && rm -rf /root/.cache \
+    && :
+
+COPY sync-test-lists.py /usr/local/bin/
+
+USER daemon

--- a/scripts/sync-test-lists.py
+++ b/scripts/sync-test-lists.py
@@ -175,6 +175,7 @@ class GitToPostgres(object):
                 insert_buf.write(line)
                 insert_buf.write("\n")
 
+            insert_buf.seek(0)
             cursor.copy_from(insert_buf, 'urls', columns=('url', 'cat_no', 'country_no', 'date_added', 'source', 'notes', 'active'))
 
     def update_urls_by_path(self, cursor, changed_path, cat_code_no, country_alpha_2_no):

--- a/scripts/sync-test-lists.py
+++ b/scripts/sync-test-lists.py
@@ -275,7 +275,7 @@ def dirname(s):
 
 def parse_args():
     p = argparse.ArgumentParser(description='test-lists: perform operations related to test-list synchronization')
-    p.add_argument('--working-dir', metavar='DIR', type=dirname, help='where we should be cloning the git repository to', required=True)
+    p.add_argument('--working-dir', metavar='DIR', type=dirname, help='The working directory for this script. It should be preserved across runs.', required=True)
     p.add_argument('--postgres', metavar='DSN', help='libpq data source name', required=True)
     opt = p.parse_args()
     return opt

--- a/scripts/sync-test-lists.py
+++ b/scripts/sync-test-lists.py
@@ -16,21 +16,6 @@ class ProgressHandler(git.remote.RemoteProgress):
     def update(self, op_code, cur_count, max_count=None, message=''):
         print('update(%s, %s, %s, %s)' % (op_code, cur_count, max_count, message))
 
-def init_repo(working_dir):
-    """
-    To be run on first run.
-    We will initially clone the repository into test-lists.tmp, but then will
-    move it into test-lists, once the database is intialized.
-    """
-    repo_dir = os.path.join(working_dir, 'test-lists.tmp')
-    if os.path.isdir(repo_dir):
-        print("%s already existing. Deleting it." % repo_dir)
-        shutil.rmtree(repo_dir)
-    repo = git.Repo.clone_from(TEST_LISTS_GIT_URL,
-                               repo_dir,
-                               progress=ProgressHandler())
-    return repo
-
 def _iterate_csv(file_path, skip_header=False):
     with open(file_path, 'r') as csvfile:
         reader = csv.reader(csvfile, delimiter=',')
@@ -38,21 +23,6 @@ def _iterate_csv(file_path, skip_header=False):
             next(reader)
         for row in reader:
             yield row
-
-def init_category_codes(working_dir, postgres):
-    pgconn = psycopg2.connect(dsn=postgres)
-    with pgconn, pgconn.cursor() as c:
-        csv_path = os.path.join(working_dir, 'test-lists.tmp', 'lists', '00-LEGEND-new_category_codes.csv')
-        for row in _iterate_csv(csv_path, skip_header=True):
-            cat_desc, cat_code, cat_old_codes, cat_long_desc = row
-            cat_old_codes = list(
-                filter(lambda x: x != "",
-                    map(lambda x: x.strip(), cat_old_codes.split(' '))))
-            c.execute('INSERT INTO url_categories (cat_code, cat_desc, cat_long_desc, cat_old_codes)'
-                      ' VALUES (%s, %s, %s, %s)'
-                      ' ON CONFLICT DO NOTHING RETURNING cat_code',
-                      (cat_code, cat_desc, cat_long_desc, cat_old_codes))
-            # XXX maybe we care to know when there is a dup?
 
 special_countries = (
     ('Unknown Country', 'ZZ', 'ZZZ'),
@@ -74,47 +44,182 @@ def get_cat_code_no(postgres):
         cat_code_no = {str(_[0]): _[1] for _ in c}
     return cat_code_no
 
-def init_countries(working_dir, postgres):
-    repo_dir = os.path.join(working_dir, 'country-util')
-    if os.path.isdir(repo_dir):
-        print("%s already existing. Deleting it." % repo_dir)
-        shutil.rmtree(repo_dir)
-    repo = git.Repo.clone_from(COUNTRY_UTIL_URL,
-                               repo_dir,
-                               progress=ProgressHandler())
-    with open(os.path.join(repo_dir, 'data', 'country-list.json')) as in_file:
-        country_list = json.load(in_file)
+CREATE_SYNC_TEST_LISTS_TABLE = """
+CREATE TABLE IF NOT EXISTS sync_test_lists
+(
+    executed_at TIMESTAMP WITH TIME ZONE,
+    commit_hash VARCHAR PRIMARY KEY
+);
+"""
 
-    pgconn = psycopg2.connect(dsn=postgres)
-    with pgconn, pgconn.cursor() as c:
-        for country in country_list:
-            alpha_2 = country['iso3166_alpha2']
-            alpha_3 = country['iso3166_alpha3']
-            full_name = country['iso3166_name']
-            name = country['name']
-            c.execute('INSERT INTO countries (full_name, name, alpha_2, alpha_3)'
-                      ' VALUES (%s, %s, %s, %s)'
-                      ' ON CONFLICT DO NOTHING RETURNING country_no',
-                      (full_name, name, alpha_2, alpha_3))
+class GitToPostgres(object):
+    def __init__(self, working_dir, pgdsn):
+        self.working_dir = working_dir
+        self.pgdsn = pgdsn
+        self.test_lists_repo = None
+        self.last_commit_hash = None
+        self.read_sync_table()
 
-        for name, alpha_2, alpha_3 in special_countries:
-            c.execute('INSERT INTO countries (full_name, name, alpha_2, alpha_3)'
-                      ' VALUES (%s, %s, %s, %s)'
-                      ' ON CONFLICT DO NOTHING RETURNING country_no',
-                      (name, name, alpha_2, alpha_3))
+    def read_sync_table(self):
+        pgconn = psycopg2.connect(dsn=self.pgdsn)
+        with pgconn, pgconn.cursor() as c:
+            c.execute(CREATE_SYNC_TEST_LISTS_TABLE)
+        with pgconn, pgconn.cursor() as c:
+            c.execute('SELECT commit_hash FROM sync_test_lists'
+                      ' ORDER BY executed_at DESC LIMIT 1;')
+            row = c.fetchone()
+        if row is not None:
+            self.last_commit_hash = row[0]
 
-def init_url_lists(working_dir, postgres, cat_code_no, country_alpha_2_no):
-    pgconn = psycopg2.connect(dsn=postgres)
-    with pgconn, pgconn.cursor() as c:
-        csv_glob = os.path.join(working_dir, 'test-lists.tmp', 'lists', '*.csv')
-        for csv_path in glob(csv_glob):
-            alpha_2 = os.path.basename(csv_path).split('.csv')[0].upper()
+    def write_sync_table(self):
+        pgconn = psycopg2.connect(dsn=self.pgdsn)
+        last_commit_hash = self.test_lists_repo.head.commit.binsha.encode('hex')
+        if last_commit_hash == self.last_commit_hash:
+            print("Already in sync")
+            return
+
+        with pgconn, pgconn.cursor() as c:
+            c.execute('INSERT INTO sync_test_lists (executed_at, commit_hash)'
+                      ' VALUES (NOW(), %s)',
+                      (last_commit_hash, ))
+
+    def pull_or_clone_test_lists(self):
+        repo_dir = os.path.join(self.working_dir, 'test-lists')
+
+        if os.path.isdir(repo_dir):
+            print("%s already existing" % repo_dir)
+            try:
+                self.test_lists_repo = git.Repo(repo_dir)
+                self.test_lists_repo.remotes.origin.pull()
+            except Exception as exc:
+                print("Failed to pull %s, deleting" % exc)
+                shutil.rmtree(repo_dir)
+                self.pull_or_clone_test_lists()
+        else:
+            self.test_lists_repo = git.Repo.clone_from(TEST_LISTS_GIT_URL,
+                                                       repo_dir,
+                                                       progress=ProgressHandler())
+
+    def init_category_codes(self):
+        pgconn = psycopg2.connect(dsn=self.pgdsn)
+        with pgconn, pgconn.cursor() as c:
+            csv_path = os.path.join(
+                    self.working_dir,
+                    'test-lists',
+                    'lists',
+                    '00-LEGEND-new_category_codes.csv'
+            )
+            for row in _iterate_csv(csv_path, skip_header=True):
+                cat_desc, cat_code, cat_old_codes, cat_long_desc = row
+                cat_old_codes = list(
+                    filter(lambda x: x != "",
+                        map(lambda x: x.strip(), cat_old_codes.split(' '))))
+                c.execute('INSERT INTO url_categories (cat_code, cat_desc, cat_long_desc, cat_old_codes)'
+                          ' VALUES (%s, %s, %s, %s)'
+                          ' ON CONFLICT DO NOTHING RETURNING cat_code',
+                          (cat_code, cat_desc, cat_long_desc, cat_old_codes))
+
+    def init_countries(self):
+        repo_dir = os.path.join(self.working_dir, 'country-util')
+        if os.path.isdir(repo_dir):
+            print("%s already existing. Deleting it." % repo_dir)
+            shutil.rmtree(repo_dir)
+        repo = git.Repo.clone_from(COUNTRY_UTIL_URL,
+                                   repo_dir,
+                                   progress=ProgressHandler())
+        with open(os.path.join(repo_dir, 'data', 'country-list.json')) as in_file:
+            country_list = json.load(in_file)
+
+        pgconn = psycopg2.connect(dsn=self.pgdsn)
+        with pgconn, pgconn.cursor() as c:
+            for country in country_list:
+                alpha_2 = country['iso3166_alpha2']
+                alpha_3 = country['iso3166_alpha3']
+                full_name = country['iso3166_name']
+                name = country['name']
+                c.execute('INSERT INTO countries (full_name, name, alpha_2, alpha_3)'
+                          ' VALUES (%s, %s, %s, %s)'
+                          ' ON CONFLICT DO NOTHING RETURNING country_no',
+                          (full_name, name, alpha_2, alpha_3))
+
+            for name, alpha_2, alpha_3 in special_countries:
+                c.execute('INSERT INTO countries (full_name, name, alpha_2, alpha_3)'
+                          ' VALUES (%s, %s, %s, %s)'
+                          ' ON CONFLICT DO NOTHING RETURNING country_no',
+                          (name, name, alpha_2, alpha_3))
+
+    def init_url_lists(self):
+        cat_code_no = get_cat_code_no(self.pgdsn)
+        country_alpha_2_no = get_country_alpha_2_no(self.pgdsn)
+        pgconn = psycopg2.connect(dsn=self.pgdsn)
+
+        with pgconn, pgconn.cursor() as c:
+            csv_glob = os.path.join(self.working_dir, 'test-lists.tmp', 'lists', '*.csv')
+            for csv_path in glob(csv_glob):
+                alpha_2 = os.path.basename(csv_path).split('.csv')[0].upper()
+                if alpha_2 == 'GLOBAL':
+                    alpha_2 = 'XX' # We use XX to denote the global country code
+
+                if len(alpha_2) != 2: # Skip every non two letter country code (ex. 00-LEGEND-category_codes)
+                    continue
+
+                for row in _iterate_csv(csv_path, skip_header=True):
+                    url, cat_code, _, date_added, source, notes = row
+                    try:
+                        cat_no = cat_code_no[cat_code]
+                    except KeyError:
+                        print("INVALID category code %s" % cat_code)
+                        continue
+                    try:
+                        country_no = country_alpha_2_no[alpha_2]
+                    except KeyError:
+                        print("INVALID country code %s" % alpha_2)
+                        continue
+                    try:
+                        print("inserting into urls")
+                        c.execute('INSERT INTO urls (url, cat_no, country_no, date_added, source, notes, active)'
+                                  ' VALUES (%s, %s, %s, %s, %s, %s, %s)'
+                                  ' ON CONFLICT DO NOTHING RETURNING url_no',
+                                  (url, cat_no, country_no, date_added, source, notes, True))
+                    except:
+                        print("INVALID row in %s: %s" % (csv_path, row))
+                        raise RuntimeError("INVALID row in %s: %s" % (csv_path, row))
+
+    def update_urls_by_path(self, changed_path, cat_code_no, country_alpha_2_no):
+        pgconn = psycopg2.connect(dsn=self.pgdsn)
+
+        with pgconn, pgconn.cursor() as c:
+            csv_path = os.path.join(self.working_dir, 'test-lists', changed_path)
+            alpha_2 = os.path.basename(changed_path).split('.csv')[0].upper()
             if alpha_2 == 'GLOBAL':
                 alpha_2 = 'XX' # We use XX to denote the global country code
 
             if len(alpha_2) != 2: # Skip every non two letter country code (ex. 00-LEGEND-category_codes)
-                continue
+                return
 
+            country_no = country_alpha_2_no[alpha_2]
+
+            # for each URL in DB, if it's not in the newest CSV, mark it inactive
+            c.execute('SELECT url_no, url FROM urls'
+                      ' WHERE country_no = %s AND active = %s', (country_no, True))
+            db_urlno_urls = [_ for _ in c]
+            csv_urls = set([row[0] for row in _iterate_csv(csv_path, skip_header=True)]) # XXX check for dupes, etc
+            print("for country %s, have %s active urls in db" % (alpha_2, len(db_urlno_urls)))
+            print("for country %s, have %s urls in newest csv" % (alpha_2, len(csv_urls)))
+            for db_urlno_url in db_urlno_urls:
+                if db_urlno_url[1] not in csv_urls:
+                    # mark inactive
+                    try:
+                        c.execute('UPDATE urls '
+                                  'SET active = %s'
+                                  ' WHERE url_no = %s',
+                                  (False, db_urlno_url[0]))
+                    except:
+                        print("Failed to mark url_no:%s inactive" % db_urlno_url[0])
+                        raise RuntimeError("Failed to mark url_no:%s inactive" % db_urlno_url[0])
+
+            # now go through urls in the newest csv. insert them if they're *not*
+            # in the db, and update them if they *are* in the db.
             for row in _iterate_csv(csv_path, skip_header=True):
                 url, cat_code, _, date_added, source, notes = row
                 try:
@@ -127,144 +232,68 @@ def init_url_lists(working_dir, postgres, cat_code_no, country_alpha_2_no):
                 except KeyError:
                     print("INVALID country code %s" % alpha_2)
                     continue
-                try:
-                    print("inserting into urls")
-                    c.execute('INSERT INTO urls (url, cat_no, country_no, date_added, source, notes, active)'
-                              ' VALUES (%s, %s, %s, %s, %s, %s, %s)'
-                              ' ON CONFLICT DO NOTHING RETURNING url_no',
-                              (url, cat_no, country_no, date_added, source, notes, True))
-                except:
-                    print("INVALID row in %s: %s" % (csv_path, row))
-                    raise RuntimeError("INVALID row in %s: %s" % (csv_path, row))
 
-def sync_repo(working_dir):
-    diffs = []
-    repo_dir = os.path.join(working_dir, 'test-lists')
-    if not os.path.isdir(repo_dir):
-        print("%s does not exist. Try running with --init" % repo_dir)
-        raise RuntimeError("%s does not exist" % repo_dir)
-    repo = git.Repo(repo_dir)
-    previous_commit = repo.head.commit
-    repo.remotes.origin.pull()
-    if repo.head.commit != previous_commit:
-        diffs = previous_commit.diff(repo.head.commit)
-    return diffs
-
-
-def update_country_list(changed_path, working_dir, postgres, cat_code_no, country_alpha_2_no):
-    pgconn = psycopg2.connect(dsn=postgres)
-
-    with pgconn, pgconn.cursor() as c:
-        csv_path = os.path.join(working_dir, 'test-lists', changed_path)
-        alpha_2 = os.path.basename(changed_path).split('.csv')[0].upper()
-        if alpha_2 == 'GLOBAL':
-            alpha_2 = 'XX' # We use XX to denote the global country code
-
-        if len(alpha_2) != 2: # Skip every non two letter country code (ex. 00-LEGEND-category_codes)
-            return
-
-        country_no = country_alpha_2_no[alpha_2]
-
-        # for each URL in DB, if it's not in the newest CSV, mark it inactive
-        c.execute('SELECT url_no, url FROM urls'
-                  ' WHERE country_no = %s AND active = %s', (country_no, True))
-        db_urlno_urls = [_ for _ in c]
-        csv_urls = set([row[0] for row in _iterate_csv(csv_path, skip_header=True)]) # XXX check for dupes, etc
-        print("for country %s, have %s active urls in db" % (alpha_2, len(db_urlno_urls)))
-        print("for country %s, have %s urls in newest csv" % (alpha_2, len(csv_urls)))
-        for db_urlno_url in db_urlno_urls:
-            if db_urlno_url[1] not in csv_urls:
-                # mark inactive
-                try:
-                    c.execute('UPDATE urls '
-                              'SET active = %s'
-                              ' WHERE url_no = %s',
-                              (False, db_urlno_url[0]))
-                except:
-                    print("Failed to mark url_no:%s inactive" % db_urlno_url[0])
-                    raise RuntimeError("Failed to mark url_no:%s inactive" % db_urlno_url[0])
-
-        # now go through urls in the newest csv. insert them if they're *not*
-        # in the db, and update them if they *are* in the db.
-        for row in _iterate_csv(csv_path, skip_header=True):
-            url, cat_code, _, date_added, source, notes = row
-            try:
-                cat_no = cat_code_no[cat_code]
-            except KeyError:
-                print("INVALID category code %s" % cat_code)
-                continue
-            try:
-                country_no = country_alpha_2_no[alpha_2]
-            except KeyError:
-                print("INVALID country code %s" % alpha_2)
-                continue
-
-            c.execute('SELECT cat_no, source, notes, url_no, active FROM urls'
-                      ' WHERE country_no = %s AND url = %s', (country_no, url))
-            url_in_db = [_ for _ in c]
-            if len(url_in_db) == 0:
-                try:
-                    c.execute('INSERT INTO urls (url, cat_no, country_no, date_added, source, notes, active)'
-                              ' VALUES (%s, %s, %s, %s, %s, %s, %s)'
-                              ' ON CONFLICT DO NOTHING RETURNING url_no',
-                              (url, cat_no, country_no, date_added, source, notes, True))
-                except:
-                    print("INVALID row in %s: %s" % (csv_path, row))
-                    raise RuntimeError("INVALID row in %s: %s" % (csv_path, row))
-            elif len(url_in_db) == 1:
-                url_no = url_in_db[0][3]
-                if url_in_db[0][0] != cat_no or url_in_db[0][1] != source or url_in_db[0][2] != notes or url_in_db[0][4] != True:
+                c.execute('SELECT cat_no, source, notes, url_no, active FROM urls'
+                          ' WHERE country_no = %s AND url = %s', (country_no, url))
+                url_in_db = [_ for _ in c]
+                if len(url_in_db) == 0:
                     try:
-                        c.execute('UPDATE urls '
-                                  'SET cat_no = %s,'
-                                  '    source = %s,'
-                                  '    notes = %s,'
-                                  '    active = %s'
-                                  ' WHERE url_no = %s',
-                                  (cat_no, source, notes, True, url_no))
+                        c.execute('INSERT INTO urls (url, cat_no, country_no, date_added, source, notes, active)'
+                                  ' VALUES (%s, %s, %s, %s, %s, %s, %s)'
+                                  ' ON CONFLICT DO NOTHING RETURNING url_no',
+                                  (url, cat_no, country_no, date_added, source, notes, True))
                     except:
-                        print("Failed to update %s with values: %s" % (csv_path, row))
-                        raise RuntimeError("Failed to update %s with values: %s" % (csv_path, row))
+                        print("INVALID row in %s: %s" % (csv_path, row))
+                        raise RuntimeError("INVALID row in %s: %s" % (csv_path, row))
+                elif len(url_in_db) == 1:
+                    url_no = url_in_db[0][3]
+                    if url_in_db[0][0] != cat_no or url_in_db[0][1] != source or url_in_db[0][2] != notes or url_in_db[0][4] != True:
+                        try:
+                            c.execute('UPDATE urls '
+                                      'SET cat_no = %s,'
+                                      '    source = %s,'
+                                      '    notes = %s,'
+                                      '    active = %s'
+                                      ' WHERE url_no = %s',
+                                      (cat_no, source, notes, True, url_no))
+                        except:
+                            print("Failed to update %s with values: %s" % (csv_path, row))
+                            raise RuntimeError("Failed to update %s with values: %s" % (csv_path, row))
+                    else:
+                        pass
+                        #print("Value unchanged, skipping")
                 else:
-                    pass
-                    #print("Value unchanged, skipping")
-            else:
-                print("Duplicate entries found in database. Something is wrong see: %s" % url_in_db)
+                    print("Duplicate entries found in database. Something is wrong see: %s" % url_in_db)
 
-def update(working_dir, postgres):
-    print("Checking if we need to update")
-    diffs = sync_repo(working_dir)
+    def update_url_lists(self):
+        last_commit = self.test_lists_repo.commit(self.last_commit_hash)
+        if self.test_lists_repo.head.commit == last_commit:
+            print("No changes made")
+            return
+        diffs = last_commit.diff(self.test_lists_repo.head.commit)
+        cat_code_no = get_cat_code_no(self.pgdsn)
+        country_alpha_2_no = get_country_alpha_2_no(self.pgdsn)
+        for diff in diffs:
+            changed_path = diff.b_path
+            if not changed_path.startswith("lists/"):
+                continue
+            if not changed_path.endswith(".csv"):
+                continue
+            print("Updating test list: %s" % changed_path)
+            self.update_urls_by_path(changed_path, cat_code_no, country_alpha_2_no)
 
-    if len(diffs) == 0:
-        print("no diffs")
-        return
+    def run(self):
+        self.pull_or_clone_test_lists()
+        if self.last_commit_hash is None:
+            print("Initialising category codes")
+            self.init_category_codes()
+            print("Initialising countries")
+            self.init_countries()
+            self.init_url_lists()
+        else:
+            self.update_url_lists()
 
-    cat_code_no = get_cat_code_no(postgres)
-    country_alpha_2_no = get_country_alpha_2_no(postgres)
-    for diff in diffs:
-        changed_path = diff.b_path
-        if not changed_path.startswith("lists/"):
-            continue
-        if not changed_path.endswith(".csv"):
-            continue
-        print("Updating test list: %s" % changed_path)
-        update_country_list(changed_path, working_dir, postgres, cat_code_no, country_alpha_2_no)
-
-def init(working_dir, postgres):
-    print("Initialising git repo")
-    init_repo(working_dir)
-    print("Initialising category codes")
-    init_category_codes(working_dir, postgres)
-    print("Initialising countries")
-    init_countries(working_dir, postgres)
-
-    print("Initialising url lists")
-    cat_code_no = get_cat_code_no(postgres)
-    country_alpha_2_no = get_country_alpha_2_no(postgres)
-    init_url_lists(working_dir, postgres, cat_code_no, country_alpha_2_no)
-    # Mark it as initialized
-    os.rename(os.path.join(working_dir, 'test-lists.tmp'),
-              os.path.join(working_dir, 'test-lists'))
+        self.write_sync_table()
 
 def dirname(s):
     if not os.path.isdir(s):
@@ -282,9 +311,8 @@ def parse_args():
 
 def main():
     opt = parse_args()
-    if not os.path.isdir(os.path.join(opt.working_dir, 'test-lists')):
-        init(opt.working_dir, opt.postgres)
-    update(opt.working_dir, opt.postgres)
+    gtp = GitToPostgres(working_dir=opt.working_dir, pgdsn=opt.postgres)
+    gtp.run()
 
 if __name__ == "__main__":
     main()

--- a/scripts/sync-test-lists.py
+++ b/scripts/sync-test-lists.py
@@ -71,17 +71,15 @@ class GitToPostgres(object):
         if row is not None:
             self.last_commit_hash = row[0]
 
-    def write_sync_table(self):
-        pgconn = psycopg2.connect(dsn=self.pgdsn)
+    def write_sync_table(self, cursor):
         last_commit_hash = self.test_lists_repo.head.commit.binsha.encode('hex')
         if last_commit_hash == self.last_commit_hash:
             print("Already in sync")
             return
 
-        with pgconn, pgconn.cursor() as c:
-            c.execute('INSERT INTO sync_test_lists (executed_at, commit_hash)'
-                      ' VALUES (NOW(), %s)',
-                      (last_commit_hash, ))
+        cursor.execute('INSERT INTO sync_test_lists (executed_at, commit_hash)'
+                  ' VALUES (NOW(), %s)',
+                  (last_commit_hash, ))
 
     def pull_or_clone_test_lists(self):
         repo_dir = os.path.join(self.working_dir, 'test-lists')
@@ -100,26 +98,24 @@ class GitToPostgres(object):
                                                        repo_dir,
                                                        progress=ProgressHandler())
 
-    def init_category_codes(self):
-        pgconn = psycopg2.connect(dsn=self.pgdsn)
-        with pgconn, pgconn.cursor() as c:
-            csv_path = os.path.join(
-                    self.working_dir,
-                    'test-lists',
-                    'lists',
-                    '00-LEGEND-new_category_codes.csv'
-            )
-            for row in _iterate_csv(csv_path, skip_header=True):
-                cat_desc, cat_code, cat_old_codes, cat_long_desc = row
-                cat_old_codes = list(
-                    filter(lambda x: x != "",
-                        map(lambda x: x.strip(), cat_old_codes.split(' '))))
-                c.execute('INSERT INTO url_categories (cat_code, cat_desc, cat_long_desc, cat_old_codes)'
-                          ' VALUES (%s, %s, %s, %s)'
-                          ' ON CONFLICT DO NOTHING RETURNING cat_code',
-                          (cat_code, cat_desc, cat_long_desc, cat_old_codes))
+    def init_category_codes(self, cursor):
+        csv_path = os.path.join(
+                self.working_dir,
+                'test-lists',
+                'lists',
+                '00-LEGEND-new_category_codes.csv'
+        )
+        for row in _iterate_csv(csv_path, skip_header=True):
+            cat_desc, cat_code, cat_old_codes, cat_long_desc = row
+            cat_old_codes = list(
+                filter(lambda x: x != "",
+                    map(lambda x: x.strip(), cat_old_codes.split(' '))))
+            cursor.execute('INSERT INTO url_categories (cat_code, cat_desc, cat_long_desc, cat_old_codes)'
+                      ' VALUES (%s, %s, %s, %s)'
+                      ' ON CONFLICT DO NOTHING RETURNING cat_code',
+                      (cat_code, cat_desc, cat_long_desc, cat_old_codes))
 
-    def init_countries(self):
+    def init_countries(self, cursor):
         repo_dir = os.path.join(self.working_dir, 'country-util')
         if os.path.isdir(repo_dir):
             print("%s already existing. Deleting it." % repo_dir)
@@ -130,96 +126,35 @@ class GitToPostgres(object):
         with open(os.path.join(repo_dir, 'data', 'country-list.json')) as in_file:
             country_list = json.load(in_file)
 
-        pgconn = psycopg2.connect(dsn=self.pgdsn)
-        with pgconn, pgconn.cursor() as c:
-            for country in country_list:
-                alpha_2 = country['iso3166_alpha2']
-                alpha_3 = country['iso3166_alpha3']
-                full_name = country['iso3166_name']
-                name = country['name']
-                c.execute('INSERT INTO countries (full_name, name, alpha_2, alpha_3)'
-                          ' VALUES (%s, %s, %s, %s)'
-                          ' ON CONFLICT DO NOTHING RETURNING country_no',
-                          (full_name, name, alpha_2, alpha_3))
+        for country in country_list:
+            alpha_2 = country['iso3166_alpha2']
+            alpha_3 = country['iso3166_alpha3']
+            full_name = country['iso3166_name']
+            name = country['name']
+            cursor.execute('INSERT INTO countries (full_name, name, alpha_2, alpha_3)'
+                      ' VALUES (%s, %s, %s, %s)'
+                      ' ON CONFLICT DO NOTHING RETURNING country_no',
+                      (full_name, name, alpha_2, alpha_3))
 
-            for name, alpha_2, alpha_3 in special_countries:
-                c.execute('INSERT INTO countries (full_name, name, alpha_2, alpha_3)'
-                          ' VALUES (%s, %s, %s, %s)'
-                          ' ON CONFLICT DO NOTHING RETURNING country_no',
-                          (name, name, alpha_2, alpha_3))
+        for name, alpha_2, alpha_3 in special_countries:
+            cursor.execute('INSERT INTO countries (full_name, name, alpha_2, alpha_3)'
+                      ' VALUES (%s, %s, %s, %s)'
+                      ' ON CONFLICT DO NOTHING RETURNING country_no',
+                      (name, name, alpha_2, alpha_3))
 
-    def init_url_lists(self):
+    def init_url_lists(self, cursor):
         cat_code_no = get_cat_code_no(self.pgdsn)
         country_alpha_2_no = get_country_alpha_2_no(self.pgdsn)
-        pgconn = psycopg2.connect(dsn=self.pgdsn)
 
-        with pgconn, pgconn.cursor() as c:
-            csv_glob = os.path.join(self.working_dir, 'test-lists.tmp', 'lists', '*.csv')
-            for csv_path in glob(csv_glob):
-                alpha_2 = os.path.basename(csv_path).split('.csv')[0].upper()
-                if alpha_2 == 'GLOBAL':
-                    alpha_2 = 'XX' # We use XX to denote the global country code
-
-                if len(alpha_2) != 2: # Skip every non two letter country code (ex. 00-LEGEND-category_codes)
-                    continue
-
-                for row in _iterate_csv(csv_path, skip_header=True):
-                    url, cat_code, _, date_added, source, notes = row
-                    try:
-                        cat_no = cat_code_no[cat_code]
-                    except KeyError:
-                        print("INVALID category code %s" % cat_code)
-                        continue
-                    try:
-                        country_no = country_alpha_2_no[alpha_2]
-                    except KeyError:
-                        print("INVALID country code %s" % alpha_2)
-                        continue
-                    try:
-                        print("inserting into urls")
-                        c.execute('INSERT INTO urls (url, cat_no, country_no, date_added, source, notes, active)'
-                                  ' VALUES (%s, %s, %s, %s, %s, %s, %s)'
-                                  ' ON CONFLICT DO NOTHING RETURNING url_no',
-                                  (url, cat_no, country_no, date_added, source, notes, True))
-                    except:
-                        print("INVALID row in %s: %s" % (csv_path, row))
-                        raise RuntimeError("INVALID row in %s: %s" % (csv_path, row))
-
-    def update_urls_by_path(self, changed_path, cat_code_no, country_alpha_2_no):
-        pgconn = psycopg2.connect(dsn=self.pgdsn)
-
-        with pgconn, pgconn.cursor() as c:
-            csv_path = os.path.join(self.working_dir, 'test-lists', changed_path)
-            alpha_2 = os.path.basename(changed_path).split('.csv')[0].upper()
+        csv_glob = os.path.join(self.working_dir, 'test-lists.tmp', 'lists', '*.csv')
+        for csv_path in glob(csv_glob):
+            alpha_2 = os.path.basename(csv_path).split('.csv')[0].upper()
             if alpha_2 == 'GLOBAL':
                 alpha_2 = 'XX' # We use XX to denote the global country code
 
             if len(alpha_2) != 2: # Skip every non two letter country code (ex. 00-LEGEND-category_codes)
-                return
+                continue
 
-            country_no = country_alpha_2_no[alpha_2]
-
-            # for each URL in DB, if it's not in the newest CSV, mark it inactive
-            c.execute('SELECT url_no, url FROM urls'
-                      ' WHERE country_no = %s AND active = %s', (country_no, True))
-            db_urlno_urls = [_ for _ in c]
-            csv_urls = set([row[0] for row in _iterate_csv(csv_path, skip_header=True)]) # XXX check for dupes, etc
-            print("for country %s, have %s active urls in db" % (alpha_2, len(db_urlno_urls)))
-            print("for country %s, have %s urls in newest csv" % (alpha_2, len(csv_urls)))
-            for db_urlno_url in db_urlno_urls:
-                if db_urlno_url[1] not in csv_urls:
-                    # mark inactive
-                    try:
-                        c.execute('UPDATE urls '
-                                  'SET active = %s'
-                                  ' WHERE url_no = %s',
-                                  (False, db_urlno_url[0]))
-                    except:
-                        print("Failed to mark url_no:%s inactive" % db_urlno_url[0])
-                        raise RuntimeError("Failed to mark url_no:%s inactive" % db_urlno_url[0])
-
-            # now go through urls in the newest csv. insert them if they're *not*
-            # in the db, and update them if they *are* in the db.
             for row in _iterate_csv(csv_path, skip_header=True):
                 url, cat_code, _, date_added, source, notes = row
                 try:
@@ -232,40 +167,94 @@ class GitToPostgres(object):
                 except KeyError:
                     print("INVALID country code %s" % alpha_2)
                     continue
+                try:
+                    print("inserting into urls")
+                    cursor.execute('INSERT INTO urls (url, cat_no, country_no, date_added, source, notes, active)'
+                              ' VALUES (%s, %s, %s, %s, %s, %s, %s)'
+                              ' ON CONFLICT DO NOTHING RETURNING url_no',
+                              (url, cat_no, country_no, date_added, source, notes, True))
+                except:
+                    print("INVALID row in %s: %s" % (csv_path, row))
+                    raise RuntimeError("INVALID row in %s: %s" % (csv_path, row))
 
-                c.execute('SELECT cat_no, source, notes, url_no, active FROM urls'
-                          ' WHERE country_no = %s AND url = %s', (country_no, url))
-                url_in_db = [_ for _ in c]
-                if len(url_in_db) == 0:
+    def update_urls_by_path(self, cursor, changed_path, cat_code_no, country_alpha_2_no):
+        csv_path = os.path.join(self.working_dir, 'test-lists', changed_path)
+        alpha_2 = os.path.basename(changed_path).split('.csv')[0].upper()
+        if alpha_2 == 'GLOBAL':
+            alpha_2 = 'XX' # We use XX to denote the global country code
+
+        if len(alpha_2) != 2: # Skip every non two letter country code (ex. 00-LEGEND-category_codes)
+            return
+
+        country_no = country_alpha_2_no[alpha_2]
+
+        # for each URL in DB, if it's not in the newest CSV, mark it inactive
+        cursor.execute('SELECT url_no, url FROM urls'
+                  ' WHERE country_no = %s AND active = %s', (country_no, True))
+        db_urlno_urls = [_ for _ in cursor]
+        csv_urls = set([row[0] for row in _iterate_csv(csv_path, skip_header=True)]) # XXX check for dupes, etc
+        print("for country %s, have %s active urls in db" % (alpha_2, len(db_urlno_urls)))
+        print("for country %s, have %s urls in newest csv" % (alpha_2, len(csv_urls)))
+        for db_urlno_url in db_urlno_urls:
+            if db_urlno_url[1] not in csv_urls:
+                # mark inactive
+                try:
+                    cursor.execute('UPDATE urls '
+                              'SET active = %s'
+                              ' WHERE url_no = %s',
+                              (False, db_urlno_url[0]))
+                except:
+                    print("Failed to mark url_no:%s inactive" % db_urlno_url[0])
+                    raise RuntimeError("Failed to mark url_no:%s inactive" % db_urlno_url[0])
+
+        # now go through urls in the newest csv. insert them if they're *not*
+        # in the db, and update them if they *are* in the db.
+        for row in _iterate_csv(csv_path, skip_header=True):
+            url, cat_code, _, date_added, source, notes = row
+            try:
+                cat_no = cat_code_no[cat_code]
+            except KeyError:
+                print("INVALID category code %s" % cat_code)
+                continue
+            try:
+                country_no = country_alpha_2_no[alpha_2]
+            except KeyError:
+                print("INVALID country code %s" % alpha_2)
+                continue
+
+            cursor.execute('SELECT cat_no, source, notes, url_no, active FROM urls'
+                      ' WHERE country_no = %s AND url = %s', (country_no, url))
+            url_in_db = [_ for _ in c]
+            if len(url_in_db) == 0:
+                try:
+                    cursor.execute('INSERT INTO urls (url, cat_no, country_no, date_added, source, notes, active)'
+                              ' VALUES (%s, %s, %s, %s, %s, %s, %s)'
+                              ' ON CONFLICT DO NOTHING RETURNING url_no',
+                              (url, cat_no, country_no, date_added, source, notes, True))
+                except:
+                    print("INVALID row in %s: %s" % (csv_path, row))
+                    raise RuntimeError("INVALID row in %s: %s" % (csv_path, row))
+            elif len(url_in_db) == 1:
+                url_no = url_in_db[0][3]
+                if url_in_db[0][0] != cat_no or url_in_db[0][1] != source or url_in_db[0][2] != notes or url_in_db[0][4] != True:
                     try:
-                        c.execute('INSERT INTO urls (url, cat_no, country_no, date_added, source, notes, active)'
-                                  ' VALUES (%s, %s, %s, %s, %s, %s, %s)'
-                                  ' ON CONFLICT DO NOTHING RETURNING url_no',
-                                  (url, cat_no, country_no, date_added, source, notes, True))
+                        cursor.execute('UPDATE urls '
+                                  'SET cat_no = %s,'
+                                  '    source = %s,'
+                                  '    notes = %s,'
+                                  '    active = %s'
+                                  ' WHERE url_no = %s',
+                                  (cat_no, source, notes, True, url_no))
                     except:
-                        print("INVALID row in %s: %s" % (csv_path, row))
-                        raise RuntimeError("INVALID row in %s: %s" % (csv_path, row))
-                elif len(url_in_db) == 1:
-                    url_no = url_in_db[0][3]
-                    if url_in_db[0][0] != cat_no or url_in_db[0][1] != source or url_in_db[0][2] != notes or url_in_db[0][4] != True:
-                        try:
-                            c.execute('UPDATE urls '
-                                      'SET cat_no = %s,'
-                                      '    source = %s,'
-                                      '    notes = %s,'
-                                      '    active = %s'
-                                      ' WHERE url_no = %s',
-                                      (cat_no, source, notes, True, url_no))
-                        except:
-                            print("Failed to update %s with values: %s" % (csv_path, row))
-                            raise RuntimeError("Failed to update %s with values: %s" % (csv_path, row))
-                    else:
-                        pass
-                        #print("Value unchanged, skipping")
+                        print("Failed to update %s with values: %s" % (csv_path, row))
+                        raise RuntimeError("Failed to update %s with values: %s" % (csv_path, row))
                 else:
-                    print("Duplicate entries found in database. Something is wrong see: %s" % url_in_db)
+                    pass
+                    #print("Value unchanged, skipping")
+            else:
+                print("Duplicate entries found in database. Something is wrong see: %s" % url_in_db)
 
-    def update_url_lists(self):
+    def update_url_lists(self, cursor):
         last_commit = self.test_lists_repo.commit(self.last_commit_hash)
         if self.test_lists_repo.head.commit == last_commit:
             print("No changes made")
@@ -280,20 +269,23 @@ class GitToPostgres(object):
             if not changed_path.endswith(".csv"):
                 continue
             print("Updating test list: %s" % changed_path)
-            self.update_urls_by_path(changed_path, cat_code_no, country_alpha_2_no)
+            self.update_urls_by_path(cursor, changed_path, cat_code_no, country_alpha_2_no)
 
     def run(self):
         self.pull_or_clone_test_lists()
-        if self.last_commit_hash is None:
-            print("Initialising category codes")
-            self.init_category_codes()
-            print("Initialising countries")
-            self.init_countries()
-            self.init_url_lists()
-        else:
-            self.update_url_lists()
 
-        self.write_sync_table()
+        pgconn = psycopg2.connect(dsn=self.pgdsn)
+        with pgconn, pgconn.cursor() as cursor:
+            if self.last_commit_hash is None:
+                print("Initialising category codes")
+                self.init_category_codes(cursor)
+                print("Initialising countries")
+                self.init_countries(cursor)
+                self.init_url_lists(cursor)
+            else:
+                self.update_url_lists(cursor)
+
+            self.write_sync_table(cursor)
 
 def dirname(s):
     if not os.path.isdir(s):

--- a/scripts/sync-test-lists.py
+++ b/scripts/sync-test-lists.py
@@ -52,24 +52,30 @@ CREATE TABLE IF NOT EXISTS sync_test_lists
 class GitToPostgres(object):
     def __init__(self, working_dir, pgdsn):
         self.working_dir = working_dir
-        self.pgdsn = pgdsn
         self.test_lists_repo = None
-        self.last_commit_hash = None
-        self.read_sync_table()
+        self.pgconn = psycopg2.connect(dsn=pgdsn)
+        with self.pgconn: # PG transaction
+            self.last_commit_hash = self.get_db_head()
 
-    def read_sync_table(self):
-        pgconn = psycopg2.connect(dsn=self.pgdsn)
-        with pgconn, pgconn.cursor() as c:
+    def get_db_head(self):
+        with self.pgconn.cursor() as c:
             c.execute(CREATE_SYNC_TEST_LISTS_TABLE)
-        with pgconn, pgconn.cursor() as c:
             c.execute('SELECT commit_hash FROM sync_test_lists'
                       ' ORDER BY executed_at DESC LIMIT 1;')
             row = c.fetchone()
         if row is not None:
-            self.last_commit_hash = row[0]
+            return row[0]
+        else:
+            return None
+
+    def get_remote_head(self):
+        return git.cmd.Git().ls_remote(TEST_LISTS_GIT_URL, 'HEAD').split('\t', 1)[0]
+
+    def get_local_head(self):
+        return self.test_lists_repo.head.commit.binsha.encode('hex')
 
     def write_sync_table(self, cursor):
-        last_commit_hash = self.test_lists_repo.head.commit.binsha.encode('hex')
+        last_commit_hash = self.get_local_head()
         if last_commit_hash == self.last_commit_hash:
             print("Already in sync")
             return
@@ -283,10 +289,19 @@ class GitToPostgres(object):
             self.update_urls_by_path(cursor, changed_path, cat_code_no, country_alpha_2_no)
 
     def run(self):
+        if self.get_remote_head() == self.last_commit_hash:
+            # short-circuit without fetching git repo
+            print("Already in sync")
+            return
+
         self.pull_or_clone_test_lists()
 
-        pgconn = psycopg2.connect(dsn=self.pgdsn)
-        with pgconn, pgconn.cursor() as cursor:
+        with self.pgconn, self.pgconn.cursor() as cursor: # PG transaction
+            # `sync_test_lists` table is used to prevent two concurrent runs of
+            # the script. Maybe it's enough to rely on transaction semantics,
+            # but it needs more careful review of the code, so let it be lock :)
+            cursor.execute('LOCK TABLE sync_test_lists IN ACCESS EXCLUSIVE MODE NOWAIT')
+
             if self.last_commit_hash is None:
                 print("Initialising category codes")
                 self.init_category_codes(cursor)

--- a/scripts/sync-test-lists.py
+++ b/scripts/sync-test-lists.py
@@ -224,7 +224,7 @@ class GitToPostgres(object):
 
             cursor.execute('SELECT cat_no, source, notes, url_no, active FROM urls'
                       ' WHERE country_no = %s AND url = %s', (country_no, url))
-            url_in_db = [_ for _ in c]
+            url_in_db = [_ for _ in cursor]
             if len(url_in_db) == 0:
                 try:
                     cursor.execute('INSERT INTO urls (url, cat_no, country_no, date_added, source, notes, active)'

--- a/scripts/sync-test-lists.py
+++ b/scripts/sync-test-lists.py
@@ -25,7 +25,7 @@ def _iterate_csv(file_path, skip_header=False):
         for row in reader:
             yield row
 
-special_countries = (
+SPECIAL_COUNTRIES = (
     ('Unknown Country', 'ZZ', 'ZZZ'),
     ('Global', 'XX', 'XXX'),
     ('European Union', 'EU', 'EUE')
@@ -117,7 +117,7 @@ class GitToPostgres(object):
         if os.path.isdir(repo_dir):
             print("%s already existing. Deleting it." % repo_dir)
             shutil.rmtree(repo_dir)
-        repo = git.Repo.clone_from(COUNTRY_UTIL_URL,
+        git.Repo.clone_from(COUNTRY_UTIL_URL,
                                    repo_dir,
                                    progress=ProgressHandler())
         with open(os.path.join(repo_dir, 'data', 'country-list.json')) as in_file:
@@ -133,7 +133,7 @@ class GitToPostgres(object):
                       ' ON CONFLICT DO NOTHING RETURNING country_no',
                       (full_name, name, alpha_2, alpha_3))
 
-        for name, alpha_2, alpha_3 in special_countries:
+        for name, alpha_2, alpha_3 in SPECIAL_COUNTRIES:
             cursor.execute('INSERT INTO countries (full_name, name, alpha_2, alpha_3)'
                       ' VALUES (%s, %s, %s, %s)'
                       ' ON CONFLICT DO NOTHING RETURNING country_no',
@@ -217,8 +217,8 @@ class GitToPostgres(object):
                               ' WHERE url_no = %s',
                               (False, url['url_no']))
                 except:
-                    print("Failed to mark url_no:%s inactive" % db_urlno_url[0])
-                    raise RuntimeError("Failed to mark url_no:%s inactive" % db_urlno_url[0])
+                    print("Failed to mark url_no:%s inactive" % url['url_no'])
+                    raise RuntimeError("Failed to mark url_no:%s inactive" % url['url_no'])
 
 
         # in the db, and update them if they *are* in the db.

--- a/scripts/sync-test-lists.py
+++ b/scripts/sync-test-lists.py
@@ -167,7 +167,7 @@ class GitToPostgres(object):
                     print("INVALID country code %s" % alpha_2)
                     continue
                 row = [url, str(cat_no), str(country_no), date_added, source, notes, 'true']
-                bad_chars = ["\r", "\n", "\t"]
+                bad_chars = ["\r", "\n", "\t", "\\"]
                 for r in row:
                     if any([c in r for c in bad_chars]):
                         raise RuntimeError("Bad char in row %s" % row)

--- a/scripts/sync-test-lists.py
+++ b/scripts/sync-test-lists.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python2.7
+
 import os
 import csv
 import json


### PR DESCRIPTION
This makes some changes to the sync-test-lists script which populates the relevant tables in the orchestra database for enabling the /api/v1/urls endpoint to work.

The workflow of this script is the following:
1. It checks if there is a history inside of the `sync_test_lists` table, if not it is considered to be a first run in which case it will populate the tables for the category codes, countries and writes all the URLs in the country lists.
2. It will pull (or clone if it's the first run) the citizenlab/test-list repository into the `workingdir/test-lists` 
3. If the `sync_test_lists` contains a history, it will take the last commit hash and do a diff of that
4. Based on the diff it will look at which paths have changed and figure out if there are new URLs to add or if some were deleted and mark them as inactive (`active = false`)
