### PR TITLE
Fix sync test lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage*.txt
 private/
 .GITHUB_TOKEN
 /vendor
+*.pyc

--- a/scripts/sync-test-lists.py
+++ b/scripts/sync-test-lists.py
@@ -290,14 +290,7 @@ class GitToPostgres(object):
             print("Updating test list: %s" % changed_path)
             self.update_urls_by_path(cursor, changed_path, cat_code_no, country_alpha_2_no)
 
-    def run(self):
-        if self.get_remote_head() == self.last_commit_hash:
-            # short-circuit without fetching git repo
-            print("Already in sync")
-            return
-
-        self.pull_or_clone_test_lists()
-
+    def sync_db(self):
         with self.pgconn, self.pgconn.cursor() as cursor: # PG transaction
             # `sync_test_lists` table is used to prevent two concurrent runs of
             # the script. Maybe it's enough to rely on transaction semantics,
@@ -314,6 +307,16 @@ class GitToPostgres(object):
                 self.update_url_lists(cursor)
 
             self.write_sync_table(cursor)
+
+    def run(self):
+        if self.get_remote_head() == self.last_commit_hash:
+            # short-circuit without fetching git repo
+            print("Already in sync")
+            return
+
+        self.pull_or_clone_test_lists()
+        self.sync_db()
+
 
 def dirname(s):
     if not os.path.isdir(s):

--- a/scripts/sync-test-lists.py
+++ b/scripts/sync-test-lists.py
@@ -224,9 +224,9 @@ class GitToPostgres(object):
                               'SET active = %s'
                               ' WHERE url_no = %s',
                               (False, url['url_no']))
-                except:
+                except Exception as exc:
                     print("Failed to mark url_no:%s inactive" % url['url_no'])
-                    raise RuntimeError("Failed to mark url_no:%s inactive" % url['url_no'])
+                    raise exc
 
 
         # in the db, and update them if they *are* in the db.
@@ -250,9 +250,9 @@ class GitToPostgres(object):
                               ' VALUES (%s, %s, %s, %s, %s, %s, %s)'
                               ' ON CONFLICT DO NOTHING RETURNING url_no',
                               (url, cat_no, country_no, date_added, source, notes, True))
-                except:
+                except Exception as exc:
                     print("INVALID row in %s: %s" % (csv_path, row))
-                    raise RuntimeError("INVALID row in %s: %s" % (csv_path, row))
+                    raise exc
             elif (url_in_db['cat_no'] != cat_no
                   or url_in_db['source'] != source
                   or url_in_db['notes'] != notes
@@ -266,9 +266,9 @@ class GitToPostgres(object):
                               '    active = %s'
                               ' WHERE url_no = %s',
                               (cat_no, source, notes, True, url_no))
-                except:
+                except Exception as exc:
                     print("Failed to update %s with values: %s" % (csv_path, row))
-                    raise RuntimeError("Failed to update %s with values: %s" % (csv_path, row))
+                    raise exc
             else:
                 # Skip items that don't require update or insert
                 continue

--- a/scripts/sync-test-lists.py
+++ b/scripts/sync-test-lists.py
@@ -258,7 +258,7 @@ class GitToPostgres(object):
                   or url_in_db['notes'] != notes
                   or url_in_db['active'] is False):
                 try:
-                    url_no = url_in_db[3]
+                    url_no = url_in_db['url_no']
                     cursor.execute('UPDATE urls '
                               'SET cat_no = %s,'
                               '    source = %s,'

--- a/scripts/test_sync_test_lists.py
+++ b/scripts/test_sync_test_lists.py
@@ -103,10 +103,10 @@ class TestGitToPostgres(unittest.TestCase):
         gtp = stl.GitToPostgres(working_dir=self.working_dir, pgdsn=self.pgdsn)
 
         gtp.pull_or_clone_test_lists()
-        gtp.test_lists_repo.head.reference = gtp.test_lists_repo.commit(HASH)
-        gtp.test_lists_repo.head.reset(index=True, working_tree=True)
+        gtp.test_lists_repo.git.reset('--hard', HASH)
         gtp.sync_db()
 
+        gtp = stl.GitToPostgres(working_dir=self.working_dir, pgdsn=self.pgdsn)
         # Now we re-run the workflow from this commit onwards
         gtp.run()
 

--- a/scripts/test_sync_test_lists.py
+++ b/scripts/test_sync_test_lists.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python2.7
+import time
+import shutil
+import docker
+import tempfile
+import unittest
+import psycopg2
+
+# XXX probably rename the file to be with underscores
+stl = __import__('sync-test-lists')
+
+
+CREATE_TABLES = """
+CREATE TYPE COLLECTOR_TYPE AS ENUM (
+    'https',
+    'onion',
+    'domain_fronted'
+);
+
+CREATE SEQUENCE collector_no_seq;
+CREATE TABLE IF NOT EXISTS collectors
+(
+  collector_no INTEGER DEFAULT nextval('collector_no_seq'::regclass) PRIMARY KEY NOT NULL,
+  type COLLECTOR_TYPE,
+  address VARCHAR,
+  front_domain VARCHAR
+);
+
+
+CREATE SEQUENCE IF NOT EXISTS url_no_seq;
+CREATE TABLE IF NOT EXISTS urls
+(
+    url_no INT NOT NULL default nextval('url_no_seq') PRIMARY KEY,
+    url VARCHAR NOT NULL,
+    cat_no INT NOT NULL,
+    country_no INT NOT NULL,
+    date_added TIMESTAMP WITH TIME ZONE NOT NULL,
+    source VARCHAR,
+    notes VARCHAR,
+    active BOOLEAN NOT NULL,
+    UNIQUE (url, country_no)
+);
+comment on table urls is 'Contains information on URLs included in the citizenlab URL list';
+
+CREATE SEQUENCE test_helper_no_seq;
+CREATE TABLE IF NOT EXISTS test_helpers
+(
+    test_helper_no INTEGER DEFAULT nextval('test_helper_no_seq'::regclass) PRIMARY KEY NOT NULL,
+    name VARCHAR NOT NULL,
+    address VARCHAR NOT NULL,
+    type VARCHAR
+
+);
+
+CREATE SEQUENCE IF NOT EXISTS country_no_seq;
+CREATE TABLE IF NOT EXISTS countries
+(
+    country_no INT NOT NULL default nextval('country_no_seq') PRIMARY KEY,
+    full_name VARCHAR UNIQUE NOT NULL,
+    name VARCHAR UNIQUE NOT NULL,
+    alpha_2 CHAR(2) UNIQUE NOT NULL,
+    alpha_3 CHAR(3) UNIQUE NOT NULL
+);
+comment on table countries is 'Contains country names and ISO codes';
+
+CREATE SEQUENCE IF NOT EXISTS cat_no_seq;
+CREATE TABLE IF NOT EXISTS url_categories
+(
+    cat_no INT NOT NULL default nextval('cat_no_seq') PRIMARY KEY,
+    cat_code VARCHAR UNIQUE NOT NULL,
+    cat_desc VARCHAR NOT NULL,
+    cat_long_desc VARCHAR,
+    cat_old_codes VARCHAR[]
+);
+"""
+
+PG_PORT = 31543
+
+class TestGitToPostgres(unittest.TestCase):
+    def setUp(self):
+        self.docker_client = docker.from_env()
+        self.pg_container = self.docker_client.containers.run(
+                "postgres",
+                detach=True,
+                ports={'5432/tcp': PG_PORT}
+        )
+        self.pgdsn = "host=localhost port={} user=postgres dbname=postgres sslmode=disable".format(PG_PORT)
+        self.working_dir = tempfile.mkdtemp()
+        print("pg_dsn: {}".format(self.pgdsn))
+        print("working_dir: {}".format(self.working_dir))
+
+        # Wait 2 seconds for docker to come online
+        time.sleep(2)
+
+        pgconn = psycopg2.connect(dsn=self.pgdsn)
+        with pgconn.cursor() as c:
+            c.execute(CREATE_TABLES)
+        pgconn.commit()
+        pgconn.close()
+
+    def test_problematic_hash(self):
+        HASH = "bee38ec1a956acf2b7b89ac5d3c1b629cd44b145"
+        gtp = stl.GitToPostgres(working_dir=self.working_dir, pgdsn=self.pgdsn)
+
+        gtp.pull_or_clone_test_lists()
+        gtp.test_lists_repo.head.reference = gtp.test_lists_repo.commit(HASH)
+        gtp.test_lists_repo.head.reset(index=True, working_tree=True)
+        gtp.sync_db()
+
+        # Now we re-run the workflow from this commit onwards
+        gtp.run()
+
+    def tearDown(self):
+        self.pg_container.remove(force=True)
+        shutil.rmtree(self.working_dir)
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
I have managed to reproduce and codify it as an integration test the issue we see on OONI Pipeline, where it ran fine 6 times, but then started failing after the citizenlab/test-lists commit `bee38ec1a956acf2b7b89ac5d3c1b629cd44b145`:

```
2018-11-27 10:00:16.117142+00 | 015b52826e1553df46149007bf784b44606f54f7
2018-10-22 12:00:20.119185+00 | 09e14f402e1e74b2a210829b513cb830d5fa39be
2018-11-27 17:00:16.19049+00 | 2336217aac3b8a6a01a9b22d770cd2df83dc1fb8
2018-11-05 17:00:17.204102+00 | 238377006ce4880f1c4cb769d410f40037138aa5
2018-11-27 15:00:15.926319+00 | 665a8384140b55531154de1383e74d2a737d7421
2018-11-05 11:00:17.140119+00 | bee38ec1a956acf2b7b89ac5d3c1b629cd44b145
```

Here is the integration test failing:
```
======================================================================
ERROR: test_problematic_hash (__main__.TestGitToPostgres)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_sync_test_lists.py", line 111, in test_problematic_hash
    gtp.run()
  File "/golang/src/github.com/ooni/orchestra/scripts/sync-test-lists.py", line 318, in run
    self.sync_db()
  File "/golang/src/github.com/ooni/orchestra/scripts/sync-test-lists.py", line 305, in sync_db
.DS_Store
    self.init_url_lists(cursor)
  File "//golang/src/github.com/ooni/orchestra/scripts/sync-test-lists.py", line 187, in init_url_lists
    cursor.copy_from(insert_buf, 'urls', columns=('url', 'cat_no', 'country_no', 'date_added', 'source', 'notes', 'active'))
IntegrityError: duplicate key value violates unique constraint "urls_url_country_no_key"
DETAIL:  Key (url, country_no)=(https://76crimes.com/anti-lgbt-laws-malaysia/, 135) already exists.
CONTEXT:  COPY urls, line 1
```

Note: the issue does not arrise on a fresh DB install.

Still need to work on a fix.