### PR TITLE
Remove unused github.com/thalesignite/crypto11 dep

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -401,14 +401,6 @@
   revision = "5ed0fc31f7f453625df314d8e66b9791e8d13003"
 
 [[projects]]
-  branch = "master"
-  digest = "1:7fd9337a2f43a16a9cf6cd5799355c68037acac8e0de06c2ec8d7cdc51dcdcb8"
-  name = "github.com/thalesignite/crypto11"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "a19b60f16f143e66ed8691e4be095c71e9a0160b"
-
-[[projects]]
   digest = "1:378ab52d8368106d6a290d4ba0fe93f97dd03fcf2d3237989940ad6f77a98ef1"
   name = "github.com/ugorji/go"
   packages = ["codec"]
@@ -519,7 +511,6 @@
     "github.com/satori/go.uuid",
     "github.com/spf13/cobra",
     "github.com/spf13/viper",
-    "github.com/thalesignite/crypto11",
     "golang.org/x/crypto/bcrypt",
     "golang.org/x/crypto/ssh/terminal",
     "gopkg.in/DATA-DOG/go-sqlmock.v1",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -45,10 +45,6 @@
   branch = "master"
   name = "github.com/miekg/pkcs11"
 
-[[override]]
-  branch = "master"
-  name = "github.com/thalesignite/crypto11"
-
 [[constraint]]
   name = "gopkg.in/DATA-DOG/go-sqlmock.v1"
   version = "1.2.0"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -45,7 +45,7 @@
   branch = "master"
   name = "github.com/miekg/pkcs11"
 
-[[constraint]]
+[[override]]
   branch = "master"
   name = "github.com/thalesignite/crypto11"
 


### PR DESCRIPTION
```
$ dep ensure
Warning: the following project(s) have [[constraint]] stanzas in Gopkg.toml:

  ✗  github.com/thalesignite/crypto11

However, these projects are not direct dependencies of the current project:
they are not imported in any .go files, nor are they in the 'required' list in
Gopkg.toml. Dep only applies [[constraint]] rules to direct dependencies, so
these rules will have no effect.

Either import/require packages from these projects so that they become direct
dependencies, or convert each [[constraint]] to an [[override]] to enforce rules
on these projects, if they happen to be transitive dependencies.
```